### PR TITLE
Fix typo as OriginalSA does not have cooling_rate param

### DIFF
--- a/mealpy/physics_based/SA.py
+++ b/mealpy/physics_based/SA.py
@@ -39,7 +39,7 @@ class OriginalSA(Optimizer):
     >>> pop_size = 2
     >>> temp_init = 100
     >>> step_size = 0.1
-    >>> model = OriginalSA(epoch, pop_size, temp_init, cooling_rate)
+    >>> model = OriginalSA(epoch, pop_size, temp_init, step_size)
     >>> best_position, best_fitness = model.solve(problem_dict1)
     >>> print(f"Solution: {best_position}, Fitness: {best_fitness}")
 


### PR DESCRIPTION
# Fix typo

## 📑 Description

- Fix typo in `OriginalSA` docs. The `OriginalSA` class does not have `cooling_rate` param. To fix it, I replace it by `step_size` param.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed