### PR TITLE
Roulette: Fix how negatives fitness are handled

### DIFF
--- a/mealpy/optimizer.py
+++ b/mealpy/optimizer.py
@@ -632,7 +632,7 @@ class Optimizer:
             list_fitness = np.array(list_fitness).flatten()
         if list_fitness.ptp() == 0:
             return int(self.generator.integers(0, len(list_fitness)))
-        if np.any(list_fitness) < 0:
+        if np.any(list_fitness < 0):
             list_fitness = list_fitness - np.min(list_fitness)
         final_fitness = list_fitness
         if self.problem.minmax == "min":


### PR DESCRIPTION
Closes #139 

## 📑 Description
When handling negative values in `optmizer.get_index_roulette_wheel_selection`, probably due to a typo, the boolean value is being compared to be less than zero `np.any(list_fitness) < 0`, instead of `np.any(list_fitness < 0)`



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

