### PR TITLE
[Fix] TS evolve breaks when no candidates

### DIFF
--- a/mealpy/math_based/TS.py
+++ b/mealpy/math_based/TS.py
@@ -91,6 +91,11 @@ class OriginalTS(Optimizer):
             list_candidates.append(agent)
             if self.mode not in self.AVAILABLE_MODES:
                 list_candidates[-1].target = self.get_target(pos_new)
+
+        # No available candidates, stay in the current x
+        if not list_candidates:
+            return
+
         list_candidates = self.update_target_for_population(list_candidates)
         best_candidate = self.get_best_agent(list_candidates, self.problem.minmax)
         self.x = best_candidate.solution

--- a/tests/math_based/test_TS.py
+++ b/tests/math_based/test_TS.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
-# Created by "Thieu" at 08:22, 17/06/2023 ----------%                                                                               
-#       Email: nguyenthieu2102@gmail.com            %                                                    
-#       Github: https://github.com/thieu1995        %                         
+# Created by "Thieu" at 08:22, 17/06/2023 ----------%
+#       Email: nguyenthieu2102@gmail.com            %
+#       Github: https://github.com/thieu1995        %
 # --------------------------------------------------%
+
+from unittest import mock
 
 from mealpy import FloatVar, TS, Optimizer
 import numpy as np
@@ -31,3 +33,17 @@ def test_TS_results(problem):
         assert isinstance(model, Optimizer)
         assert isinstance(g_best.solution, np.ndarray)
         assert len(g_best.solution) == len(model.problem.lb)
+
+
+def test_TS_no_candidates(problem):
+    """
+    Test that TS.OriginalTS does not break when evolve yields no candidates
+    because of closeness to the current position or filtered out by the tabu list.
+    """
+    ts_optimizer = TS.OriginalTS(epoch=1)
+
+    def allclose_mock(*args, **kwargs):
+        return True
+
+    with mock.patch('mealpy.math_based.TS.np.allclose', new=allclose_mock):
+        ts_optimizer.solve(problem)


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

`TS.OriginalTS.evolve` raises an error when the list of candidate solutions is empty. This can occur when candidates are filtered out either because they are close to the current position or they are present in the tabu list.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->