### PR TITLE
Adding logging for nubmer of n_workers

### DIFF
--- a/mealpy/optimizer.py
+++ b/mealpy/optimizer.py
@@ -174,6 +174,7 @@ class Optimizer:
                     self.n_workers = self.validator.check_int("n_workers", n_workers, [2, min(61, os.cpu_count() - 1)])
                 if self.mode == "thread":
                     self.n_workers = self.validator.check_int("n_workers", n_workers, [2, min(32, os.cpu_count() + 4)])
+                self.logging.info(f"The parallel mode '{self.mode}' is selected with {self.n_workers} workers.")
             else:
                 self.logger.warning(f"The parallel mode: {self.mode} is selected. But n_workers is not set. The default n_workers = 4 is used.")
                 self.n_workers = 4


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Our datascience team would like to be able to see the number of workers running when their code is deployed to a Vertex AI workbench. We would like to make sure we see the increase in n_workers. This will help with debugging an issue where users are only seeing 4 threads used by the workbench instance. 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->