### PR TITLE
(docs) add TS in readthedocs (math_base package)

### DIFF
--- a/docs/source/pages/models/mealpy.math_based.rst
+++ b/docs/source/pages/models/mealpy.math_based.rst
@@ -89,3 +89,11 @@ mealpy.math\_based.SHIO module
    :members:
    :undoc-members:
    :show-inheritance:
+
+mealpy.math\_based.TS module
+------------------------------
+
+.. automodule:: mealpy.math_based.TS
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
From the official readthedocs documentation (https://mealpy.readthedocs.io/en/latest/pages/models/mealpy.math_based.html), the TS model is missing. 
This pull request add TS model into: [docs/source/pages/models/mealpy.math_based.rst](https://github.com/thieu1995/mealpy/blob/master/docs/source/pages/models/mealpy.math_based.rst)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

