### PR TITLE
Replace BaseDE to OriginalDE in example files

### DIFF
--- a/examples/run_multi_functions.py
+++ b/examples/run_multi_functions.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 from opfunu.cec_basic import cec2014_nobias
 from pandas import DataFrame
-from mealpy.evolutionary_based.DE import BaseDE
+from mealpy.evolutionary_based.DE import OriginalDE
 
 
 PATH_RESULTS = "history/results/"
@@ -39,7 +39,7 @@ for func_name in func_names:
         "minmax": "min",
         "log_to": "console",
     }
-    model = BaseDE(epoch, pop_size, wf, cr, fit_name=func_name)
+    model = OriginalDE(epoch, pop_size, wf, cr, fit_name=func_name)
     _, best_fitness = model.solve(problem)
 
     error_full[func_name] = model.history.list_global_best_fit

--- a/examples/run_multi_functions_multi_trials.py
+++ b/examples/run_multi_functions_multi_trials.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 from opfunu.cec_basic import cec2014_nobias
 from pandas import DataFrame
-from mealpy.evolutionary_based.DE import BaseDE
+from mealpy.evolutionary_based.DE import OriginalDE
 
 
 model_name = "DE"
@@ -41,7 +41,7 @@ for func_name in func_names:
             "log_to": "console",
             "name": func_name
         }
-        model = BaseDE(epoch=epoch, pop_size=pop_size, wf=wf, cr=cr, name=model_name)
+        model = OriginalDE(epoch=epoch, pop_size=pop_size, wf=wf, cr=cr, name=model_name)
         _, best_fitness = model.solve(problem)
 
         temp = f"trial_{id_trial}"

--- a/examples/run_multi_functions_multi_trials_parallel.py
+++ b/examples/run_multi_functions_multi_trials_parallel.py
@@ -8,7 +8,7 @@ import concurrent.futures as parallel
 from pathlib import Path
 from opfunu.cec_basic import cec2014_nobias
 from pandas import DataFrame
-from mealpy.evolutionary_based.DE import BaseDE
+from mealpy.evolutionary_based.DE import OriginalDE
 
 
 model_name = "DE"
@@ -45,7 +45,7 @@ def find_minimum(function_name):
             "log_to": "console",
             "name": function_name
         }
-        model = BaseDE(epoch=epoch, pop_size=pop_size, wf=wf, cr=cr, name=model_name)
+        model = OriginalDE(epoch=epoch, pop_size=pop_size, wf=wf, cr=cr, name=model_name)
         _, best_fitness = model.solve(problem)
 
         temp = f"trial_{id_trial}"

--- a/examples/run_multi_functions_parallel.py
+++ b/examples/run_multi_functions_parallel.py
@@ -9,7 +9,7 @@ from functools import partial
 from pathlib import Path
 from opfunu.cec_basic import cec2014_nobias
 from pandas import DataFrame
-from mealpy.evolutionary_based.DE import BaseDE
+from mealpy.evolutionary_based.DE import OriginalDE
 
 
 PATH_RESULTS = "history/results/"
@@ -30,7 +30,7 @@ def find_minimum(function_name, n_dims):
         "log_to": "console",
         "name": function_name
     }
-    model = BaseDE(epoch=10, pop_size=50, wf=0.8, cr=0.9, name=model_name)
+    model = OriginalDE(epoch=10, pop_size=50, wf=0.8, cr=0.9, name=model_name)
     _, best_fitness = model.solve(problem)
     print(f"Finish function: {function_name}")
 


### PR DESCRIPTION
### Summary
Fix name in `examples/*.py` that caused an error when running the example.

### Changes
- Corrected class name from `BaseDE` to `OriginalDE`.
